### PR TITLE
fixed array casting for single mode

### DIFF
--- a/examples/input.yaml
+++ b/examples/input.yaml
@@ -14,18 +14,18 @@ melt_pool_data:
   width:
       type: "time_series"
       file_name: "data/meltPoolData/ULI_v1700_theta0_widths.txt"
-      nmodes: 100.
+      nmodes: 10.
       scale: 1.
 
   depth:
       type: "time_series"
       file_name: "data/meltPoolData/ULI_v1700_theta0_widths.txt"
-      nmodes: 100.
+      nmodes: 10.
       scale: 0.7
   hump:
       type: "time_series"
       file_name: "data/meltPoolData/ULI_v1700_theta0_widths.txt"
-      nmodes: 50.
+      nmodes: 5.
       scale: 0.3
 
 rve:


### PR DESCRIPTION
added a check for indexing if nmodes ==1.

changed np.float64(spec array) to spec array.astype(np.float64) to ensure we don't inadvertently cast to a single floating point.