### PR TITLE
Fixed 0 mod 90 rotation angle issues

### DIFF
--- a/src/raptor/core.py
+++ b/src/raptor/core.py
@@ -286,9 +286,9 @@ def compute_melt_mask_implicit(
                 resolution,
             )
 
-            is_voxel_melted = signed_dist < 1e-24
+            is_voxel_melted = signed_dist < 1e-12
 
-            is_voxel_boundary = np.abs(signed_dist) - resolution <= 1e-24
+            is_voxel_boundary = np.abs(signed_dist) - resolution <= 1e-12
 
             melt_mask_previous = melt_mask[i]
 

--- a/src/raptor/core.py
+++ b/src/raptor/core.py
@@ -286,7 +286,7 @@ def compute_melt_mask_implicit(
                 resolution,
             )
 
-            is_voxel_melted = signed_dist < 0.0
+            is_voxel_melted = signed_dist < 1e-24
 
             is_voxel_boundary = np.abs(signed_dist) - resolution <= 1e-24
 

--- a/src/raptor/structures.py
+++ b/src/raptor/structures.py
@@ -113,7 +113,9 @@ class PathVector:
 
     def set_coordinate_frame(self) -> None:
         self.distance = self.end_point - self.start_point
-        self.distance = np.where(np.abs(self.distance) < 1e-12, 1e-12, self.distance)
+        self.distance = np.sign(self.distance) * np.maximum(
+            np.abs(self.distance), 1e-12
+        )
         self.centroid = (self.end_point + self.start_point) / 2.0
 
         self.duration = self.end_time - self.start_time

--- a/src/raptor/structures.py
+++ b/src/raptor/structures.py
@@ -113,6 +113,7 @@ class PathVector:
 
     def set_coordinate_frame(self) -> None:
         self.distance = self.end_point - self.start_point
+        self.distance = np.where(np.abs(self.distance) < 1e-12, 1e-12, self.distance)
         self.centroid = (self.end_point + self.start_point) / 2.0
 
         self.duration = self.end_time - self.start_time


### PR DESCRIPTION
Issue arose due to floating point math when computing distances along nearly grid-aligned scan vectors (i.e. angle of rotation relative to nominal 0º was 0 mod 90). Fixed by asserting minimal vector component size at initialization. 

Also fixed issue with no tolerance when checking SDF.

may be a cleaner way to do this other than np.where, but seemed the most pythonic. 