### PR TITLE
Mpfilter valueerror

### DIFF
--- a/src/raptor/utilities.py
+++ b/src/raptor/utilities.py
@@ -239,8 +239,8 @@ class MeltPoolFilter:
         # timeseries related properties
         self.fs, self.duration = timeseries_params
         self.dt = 1 / self.fs
-        self.n_points = int(self.duration / self.dt + 1)
-        self.t = np.arange(0, self.duration, self.dt)
+        self.n_points = int(self.duration // self.dt + 1)
+        self.t = np.linspace(0, self.duration, self.n_points)
         # parametric representations of fluctuation scales
         self.physical_effects = {}  # contains scale description and parameters
 

--- a/src/raptor/utilities.py
+++ b/src/raptor/utilities.py
@@ -239,7 +239,7 @@ class MeltPoolFilter:
         # timeseries related properties
         self.fs, self.duration = timeseries_params
         self.dt = 1 / self.fs
-        self.n_points = int(self.duration / self.dt)
+        self.n_points = int(self.duration / self.dt + 1)
         self.t = np.arange(0, self.duration, self.dt)
         # parametric representations of fluctuation scales
         self.physical_effects = {}  # contains scale description and parameters


### PR DESCRIPTION
issue was with 0 indexing. we want to include both 0 and self.duration in the time domain.
switched to self.n_points = floordivide(self.duration, self.dt) +1 -> to include the 0 index
and then just self.t = linspace(0, self.duration, self.npoints) -> recovers the same dt.
