### PR TITLE
Deprecate spec array

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,7 +128,7 @@ parameters:
   spectral_error_fraction: 0.25
   memory_limit_mb: null
 
-# Melt pool dimension data. Can be 'time_series' or 'spectral_components'.
+# Melt pool dimension data. Must be 'time_series' (time, value) data.
 melt_pool_data:
   width:
     type: "time_series"
@@ -193,8 +193,7 @@ currently available memory.
    * The RVE min and max points *filter the scan paths for those that are near* the box defined by `min_point` and `max_point`; a large number of scan path files (such as from a part-scale build) can be downselected using this parameter setting.
 
 * **Melt Pool Data Files**: These files provide the data for the `melt_pool_data` section of the config.
-   *   If `type: "time_series"`, the file should be a two-column text or CSV file: `[time, value]`.
-   *   If `type: "spectral_components"`, the file should be a three-column text or CSV file: `[amplitude, frequency, phase]`.
+   *   With `type: "time_series"`, the file should be a two-column text or CSV file: `[time, value]`.
 
 ### 2. Python Library (API)
 

--- a/src/raptor/api.py
+++ b/src/raptor/api.py
@@ -221,13 +221,14 @@ def create_melt_pool(
         data = np.asarray(data, dtype=np.float64)
         if data.ndim != 2:
             raise ValueError(
-                f"Unsupported data shape for {key}: {data.shape}. "
-                "Must be [time, value]."
+                f"{key} data must have shape (n, 2) representing "
+                f"(time, value); got {data.shape}."
             )
         if not np.isfinite(data).all():
             raise ValueError(f"{key} data must contain only finite values.")
 
-        # Option A: Input data is a raw time-series [time, value]
+        # Only (n, 2) time-series input is supported; spectral components
+        # are always computed internally from the supplied time series.
         if data.shape[1] == 2:
             component_tolerance = tolerance
             if tolerance is not None and scale != 0.0:
@@ -239,32 +240,10 @@ def create_melt_pool(
             )
             spectral_array[:, 0] *= scale
 
-        # # Option B: Input data is a spectral array [amplitude, frequency, phase]
-        # elif data.shape[1] == 3:
-        #     if data[0, 1] != 0.0:
-        #         raise ValueError(
-        #             f"{key} spectral data must begin with a zero-frequency "
-        #             "DC component."
-        #         )
-        #     spectral_array = data.copy()
-        #     negative_amplitudes = spectral_array[:, 0] < 0.0
-        #     spectral_array[negative_amplitudes, 0] *= -1.0
-        #     spectral_array[negative_amplitudes, 2] += np.pi
-        #     spectral_array[:, 2] = np.remainder(
-        #         spectral_array[:, 2], 2.0 * np.pi
-        #     )
-        #     dc_dimension = spectral_array[0, 0] * np.cos(spectral_array[0, 2])
-        #     if dc_dimension <= 0.0:
-        #         raise ValueError(
-        #             f"{key} spectral data must have a positive DC dimension."
-        #         )
-        #     spectral_array[0] = (dc_dimension, 0.0, 0.0)
-        #     spectral_array[:, 0] *= scale
-
         else:
             raise ValueError(
-                f"Unsupported data shape for {key}: {data.shape}. "
-                f"Must be [time, value]."
+                f"{key} data must have shape (n, 2) representing "
+                f"(time, value); got {data.shape}."
             )
 
         processed_components[key] = np.asarray(spectral_array, dtype=np.float64)

--- a/src/raptor/api.py
+++ b/src/raptor/api.py
@@ -219,11 +219,10 @@ def create_melt_pool(
             )
 
         data = np.asarray(data, dtype=np.float64)
-        if data.ndim != 2 or data.shape[0] < 1:
+        if data.ndim != 2:
             raise ValueError(
                 f"Unsupported data shape for {key}: {data.shape}. "
-                "Must be [time, value] or "
-                "[amplitude, frequency, phase]."
+                "Must be [time, value]."
             )
         if not np.isfinite(data).all():
             raise ValueError(f"{key} data must contain only finite values.")
@@ -240,32 +239,32 @@ def create_melt_pool(
             )
             spectral_array[:, 0] *= scale
 
-        # Option B: Input data is a spectral array [amplitude, frequency, phase]
-        elif data.shape[1] == 3:
-            if data[0, 1] != 0.0:
-                raise ValueError(
-                    f"{key} spectral data must begin with a zero-frequency "
-                    "DC component."
-                )
-            spectral_array = data.copy()
-            negative_amplitudes = spectral_array[:, 0] < 0.0
-            spectral_array[negative_amplitudes, 0] *= -1.0
-            spectral_array[negative_amplitudes, 2] += np.pi
-            spectral_array[:, 2] = np.remainder(
-                spectral_array[:, 2], 2.0 * np.pi
-            )
-            dc_dimension = spectral_array[0, 0] * np.cos(spectral_array[0, 2])
-            if dc_dimension <= 0.0:
-                raise ValueError(
-                    f"{key} spectral data must have a positive DC dimension."
-                )
-            spectral_array[0] = (dc_dimension, 0.0, 0.0)
-            spectral_array[:, 0] *= scale
+        # # Option B: Input data is a spectral array [amplitude, frequency, phase]
+        # elif data.shape[1] == 3:
+        #     if data[0, 1] != 0.0:
+        #         raise ValueError(
+        #             f"{key} spectral data must begin with a zero-frequency "
+        #             "DC component."
+        #         )
+        #     spectral_array = data.copy()
+        #     negative_amplitudes = spectral_array[:, 0] < 0.0
+        #     spectral_array[negative_amplitudes, 0] *= -1.0
+        #     spectral_array[negative_amplitudes, 2] += np.pi
+        #     spectral_array[:, 2] = np.remainder(
+        #         spectral_array[:, 2], 2.0 * np.pi
+        #     )
+        #     dc_dimension = spectral_array[0, 0] * np.cos(spectral_array[0, 2])
+        #     if dc_dimension <= 0.0:
+        #         raise ValueError(
+        #             f"{key} spectral data must have a positive DC dimension."
+        #         )
+        #     spectral_array[0] = (dc_dimension, 0.0, 0.0)
+        #     spectral_array[:, 0] *= scale
 
         else:
             raise ValueError(
                 f"Unsupported data shape for {key}: {data.shape}. "
-                f"Must be [time, value] or [amplitude, frequency, phase]"
+                f"Must be [time, value]."
             )
 
         processed_components[key] = np.asarray(spectral_array, dtype=np.float64)

--- a/src/raptor/cli.py
+++ b/src/raptor/cli.py
@@ -75,7 +75,7 @@ def main() -> int:
             if key in scan_pattern_parameters
         }
 
-        # read melt pool dictionary (time series or spectral components)
+        # read melt pool dictionary (time series only)
         melt_pool_dict = config.get("melt_pool_data", {})
         if not isinstance(melt_pool_dict, dict):
             raise ValueError("'melt_pool_data' must be a mapping.")
@@ -83,9 +83,10 @@ def main() -> int:
         try:
             for key, dimension_config in melt_pool_dict.items():
                 datatype = dimension_config["type"]
-                if datatype not in {"time_series", "spectral_components"}:
+                if datatype not in {"time_series"}:
                     raise ValueError(
-                        f"Unsupported {key} melt-pool data type: {datatype}"
+                        f"Unsupported {key} melt-pool data type: {datatype}. "
+                        "Only 'time_series' is supported."
                     )
                 filepath = Path(dimension_config["file_name"])
                 if not filepath.is_absolute():

--- a/src/raptor/io.py
+++ b/src/raptor/io.py
@@ -17,11 +17,8 @@ from .structures import PathVector
 
 def read_data(fname: str) -> np.ndarray:
     """
-    Reads data from a .txt or .csv file.
-    Two types of input data structures are supported:
-        1. Melt pool timeseries -- T x 2 array of time, measurement
-        2. Spectral component array -- N x 3 array of amplitudes,
-           frequencies, and phases indexed by mode number.
+    Reads melt pool timeseries as as T x 2 array of time, measurement data.
+    File formats should be .txt or .csv.
     """
     if not os.path.exists(fname):
         raise FileNotFoundError(

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -95,20 +95,6 @@ def sample_time_series_data():
 
 
 @pytest.fixture
-def sample_spectral_components():
-    """Fixture providing sample spectral components."""
-    # Format: [amplitude, frequency, phase]
-    return np.array(
-        [
-            [0.0001, 0.0, 0.0],  # mode 0 (mean)
-            [0.00002, 5.0, 0.0],  # mode 1
-            [0.00001, 10.0, np.pi / 2],  # mode 2
-        ],
-        dtype=np.float64,
-    )
-
-
-@pytest.fixture
 def sample_melt_pool_dict(sample_time_series_data):
     """Fixture providing a sample melt pool dictionary."""
     return {
@@ -459,51 +445,38 @@ class TestComputeSpectralComponents:
 class TestCreateMeltPool:
     """Test cases for the create_melt_pool function."""
 
-    def test_create_melt_pool_scales_spectral_amplitudes(
-        self, sample_spectral_components
+    def test_create_melt_pool_scales_all_spectral_modes(
+        self, sample_time_series_data
     ):
         scale_factor = 2.0
+        expected = compute_spectral_components(sample_time_series_data, 3)
         melt_pool = create_melt_pool(
             {
-                "width": (sample_spectral_components, 3, scale_factor, 2.0),
-                "depth": (sample_spectral_components, 3, 1.0, 2.0),
-                "height": (sample_spectral_components, 3, 1.0, 2.0),
+                "width": (sample_time_series_data, 3, scale_factor, 2.0),
+                "depth": (sample_time_series_data, 3, 1.0, 2.0),
+                "height": (sample_time_series_data, 3, 1.0, 2.0),
             },
             enable_random_phases=False,
         )
 
         np.testing.assert_allclose(
             melt_pool.width_oscillations[:, 0],
-            scale_factor * sample_spectral_components[:, 0],
+            scale_factor * expected[:, 0],
         )
 
-    def test_signed_spectral_coefficients_use_a_conservative_envelope(self):
-        width = np.array([[148.0e-6, 0.0, 0.0], [-100.0e-6, 100.0, 0.0]])
-        constant = np.array([[50.0e-6, 0.0, 0.0]])
-        melt_pool = create_melt_pool(
-            {
-                "width": (width, 2, 1.0, 2.0),
-                "depth": (constant, 1, 1.0, 2.0),
-                "height": (constant, 1, 1.0, 2.0),
-            },
-            enable_random_phases=False,
-        )
+    def test_create_melt_pool_rejects_spectral_array_input(
+        self, sample_time_series_data
+    ):
+        """Raw (n, 3) spectral arrays are no longer an accepted input."""
+        spectral_array = np.ones((3, 3))
+        melt_pool_data = {
+            "width": (spectral_array, 3, 1.0, 2.0),
+            "depth": (sample_time_series_data, 3, 1.0, 2.0),
+            "height": (sample_time_series_data, 3, 1.0, 2.0),
+        }
 
-        assert melt_pool.width_max == pytest.approx(248.0e-6)
-        np.testing.assert_allclose(
-            melt_pool.width_oscillations[:, 0],
-            [148.0e-6, 100.0e-6],
-        )
-        np.testing.assert_allclose(
-            melt_pool.width_oscillations[:, 2],
-            [0.0, np.pi],
-        )
-        vector = PathVector(
-            np.zeros(3), np.array([1.0e-3, 0.0, 0.0]), 0.0, 1.0e-3
-        )
-        vector.set_coordinate_frame()
-        vector.set_melt_pool_properties(melt_pool)
-        assert vector.AABB[3] == pytest.approx(124.0e-6)
+        with pytest.raises(ValueError, match="shape \\(n, 2\\)"):
+            create_melt_pool(melt_pool_data, enable_random_phases=False)
 
     @pytest.mark.parametrize(
         ("field", "value", "message"),
@@ -514,20 +487,19 @@ class TestCreateMeltPool:
         ],
     )
     def test_create_melt_pool_rejects_invalid_physical_inputs(
-        self, sample_spectral_components, field, value, message
+        self, sample_time_series_data, field, value, message
     ):
-        components = sample_spectral_components.copy()
+        data = sample_time_series_data.copy()
         scale = 1.0
         shape = 2.0
         if field == "data":
-            components[1, 1] = value
+            data[1, 1] = value
         elif field == "scale":
             scale = value
         else:
             shape = value
         melt_pool_data = {
-            key: (components, 3, scale, shape)
-            for key in ("width", "depth", "height")
+            key: (data, 3, scale, shape) for key in ("width", "depth", "height")
         }
 
         with pytest.raises(ValueError, match=message):
@@ -536,17 +508,15 @@ class TestCreateMeltPool:
                 enable_random_phases=False,
             )
 
-    def test_create_melt_pool_preserves_independent_mode_counts(self):
+    def test_create_melt_pool_preserves_independent_mode_counts(
+        self, sample_time_series_data
+    ):
         """Each dimension retains only its independently selected modes."""
-        one_mode = np.array([[1.0e-4, 0.0, 0.0]])
-        three_modes = np.array(
-            [[1.0e-4, 0.0, 0.0], [1.0e-6, 1.0, 0.0], [1.0e-6, 2.0, 0.0]]
-        )
         melt_pool = create_melt_pool(
             {
-                "width": (one_mode, 1, 1.0, 2.0),
-                "depth": (three_modes, 3, 1.0, 2.0),
-                "height": (one_mode, 1, 1.0, 2.0),
+                "width": (sample_time_series_data, 1, 1.0, 2.0),
+                "depth": (sample_time_series_data, 3, 1.0, 2.0),
+                "height": (sample_time_series_data, 1, 1.0, 2.0),
             },
             enable_random_phases=False,
         )
@@ -610,7 +580,7 @@ class TestCreateMeltPool:
         data = {
             key: (invalid, 2, 1.0, 2.0) for key in ("width", "depth", "height")
         }
-        with pytest.raises(ValueError, match="Unsupported data shape"):
+        with pytest.raises(ValueError, match="shape \\(n, 2\\)"):
             create_melt_pool(data, enable_random_phases=False)
 
 
@@ -691,13 +661,17 @@ class TestComputePorosity:
             [[100.0e-6, 0.0, 0.0], [200.0e-6, 1.0, 0.0]]
         )
         constant = np.array([[20.0e-6, 0.0, 0.0]])
-        melt_pool = create_melt_pool(
-            {
-                "width": (oscillating_width, 2, 1.0, 2.0),
-                "depth": (constant, 1, 1.0, 2.0),
-                "height": (constant, 1, 1.0, 2.0),
-            },
-            enable_random_phases=False,
+        melt_pool = MeltPool(
+            oscillating_width,
+            constant,
+            constant,
+            300.0e-6,
+            20.0e-6,
+            20.0e-6,
+            2.0,
+            2.0,
+            2.0,
+            False,
         )
 
         with pytest.raises(ValueError, match="must remain positive"):


### PR DESCRIPTION
removed spec array inputs across codebase, including tests. renamed some of the tests to retain consistency